### PR TITLE
Turn into a proper minor mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Makes `completion-at-point` display possible completions via `ido–completing-r
 
 ### Installation
 
-    (autoload 'ido-at-point-setup "ido-at-point")
-    (ido-at-point-setup)
+    (autoload 'ido-at-point-mode "ido-at-point")
+    (ido-at-point-mode)
 
 ### Usage
 
@@ -16,4 +16,3 @@ Press `M-tab` or `C-M-i` to start completing.
 ### Compatibility
 
 Works only in Emacs 24 and higher. Compatible with asynchronous completion requests (including Tern's completion for JavaScript).
-

--- a/ido-at-point.el
+++ b/ido-at-point.el
@@ -30,7 +30,7 @@
 ;;; Installation:
 
 ;; (require 'ido-at-point) ; unless installed from a package
-;; (ido-at-point-setup)
+;; (ido-at-point-mode)
 
 ;;; Code:
 
@@ -64,13 +64,35 @@
   "See `ido-at-point-complete'."
   (apply 'ido-at-point-complete args))
 
+(defun ido-at-point-mode-set (enable)
+  (if enable
+      (add-to-list 'completion-in-region-functions
+                   'ido-at-point-completion-in-region)
+    (setq completion-in-region-functions
+          (delq 'ido-at-point-completion-in-region
+                completion-in-region-functions))))
+
 ;;;###autoload
-(defun ido-at-point-setup ()
-  "Sets up an alternative frontend for `completion-at-point'.
-Replaces the standard completions buffer with ido prompt by modifying
-`completion-in-region-functions'."
-  (add-to-list 'completion-in-region-functions
-               'ido-at-point-completion-in-region))
+(define-minor-mode ido-at-point-mode
+  "Global minor mode to use IDO for `completion-at-point'.
+
+When called interactively, toggle `ido-at-point-mode'.  With
+prefix ARG, enable `ido-at-point-mode' if ARG is positive,
+otherwise disable it.
+
+When called from Lisp, enable `ido-at-point-mode' if ARG is
+omitted, nil or positive.  If ARG is `toggle', toggle
+`ido-at-point-mode'.  Otherwise behave as if called
+interactively.
+
+With `ido-at-point-mode' use IDO for `completion-at-point'."
+  :variable ((memq 'ido-at-point-completion-in-region
+                   completion-in-region-functions)
+             .
+             ido-at-point-mode-set))
+
+(define-obsolete-function-alias 'ido-at-point-setup 'ido-at-point-mode
+  "0.0.2")
 
 (provide 'ido-at-point)
 


### PR DESCRIPTION
Add `ido-at-point-mode` to enable and disable IDO at point.  Works just
like `ido-at-point-setup`, but it's also interactive, and allows to
disable this feature via M-x.

`ido-at-point-setup` remains as an obsolete alias.
