### PR TITLE
Provide an option for fuzzy matching: ido-at-point-fuzzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Partial completion is *on* by default. If you don't want to get partial completi
 
     (setq ido-at-point-partial nil)
 
+Fuzzy matching is *off* by default. If you want fuzzy matching, set `ido-at-point-fuzzy` to `t`:
+
+    (setq ido-at-point-fuzzy t)
+
 ### Compatibility
 
 Works only in Emacs 24 and higher. Compatible with asynchronous completion requests (including Tern's completion for JavaScript).


### PR DESCRIPTION
For example, this would suggest "ido-at-point-complete" for the query
"iapc". This is similar to the functionality that flx-ido provides
where you can access a function quickly via its abbreviation.

The use of the fuzzy matching depends on `ido-at-point-fuzzy`; the
functionality of the package won't change unless the user changes
`ido-at-point-fuzzy`.
