### PR TITLE
Use ido-completion-in-region-function if available (r2)

### DIFF
--- a/ido-at-point.el
+++ b/ido-at-point.el
@@ -90,18 +90,34 @@ with COMPLETION."
     (delete-region (max start reg-start) end)
     (insert (substring-no-properties completion))))
 
-(defun ido-at-point-completion-in-region (next &rest args)
-  (if (window-minibuffer-p)
-      (apply next args)
-    (apply #'ido-at-point-complete args)))
+(defun ido-at-point-completion-in-region (&rest args)
+  (if (boundp 'completion-in-region-function)
+      (if (window-minibuffer-p)
+          (with-no-warnings
+            (apply #'completion--in-region args))
+        (apply #'ido-at-point-complete args))
+    (if (window-minibuffer-p)
+        (apply (car args) (cdr args))
+      (apply #'ido-at-point-complete (cdr args)))))
+
+(defvar ido-at-point-previous-completion-in-region-function nil)
 
 (defun ido-at-point-mode-set (enable)
-  (if enable
-      (add-to-list 'completion-in-region-functions
-                   'ido-at-point-completion-in-region)
-    (setq completion-in-region-functions
-          (delq 'ido-at-point-completion-in-region
-                completion-in-region-functions))))
+  (if (boundp 'completion-in-region-function)
+      (if enable
+          (setq ido-at-point-previous-completion-in-region-function
+                completion-in-region-function
+                completion-in-region-function
+                'ido-at-point-completion-in-region)
+        (setq completion-in-region-function
+              ido-at-point-previous-completion-in-region-function))
+    (with-no-warnings
+      (if enable
+          (add-to-list 'completion-in-region-functions
+                       'ido-at-point-completion-in-region)
+        (setq completion-in-region-functions
+              (delq 'ido-at-point-completion-in-region
+                    completion-in-region-functions))))))
 
 ;;;###autoload
 (define-minor-mode ido-at-point-mode
@@ -117,8 +133,12 @@ omitted, nil or positive.  If ARG is `toggle', toggle
 interactively.
 
 With `ido-at-point-mode' use ido for `completion-at-point'."
-  :variable ((memq 'ido-at-point-completion-in-region
-                   completion-in-region-functions)
+  :variable ((if (boundp 'completion-in-region-function)
+                 (eq completion-in-region-function
+                     'ido-at-point-completion-in-region)
+               (with-no-warnings
+                 (memq 'ido-at-point-completion-in-region
+                       completion-in-region-functions)))
              .
              ido-at-point-mode-set))
 


### PR DESCRIPTION
```
Starting with Emacs v25.1 `ido-completion-in-region-functions' (plural)
has been replaced with `ido-completion-in-region-function' (singular).

If bound, use `ido-completion-in-region-function' else fall back to
`ido-completion-in-region-functions'.
```

This is a fixed revision of #12, which was reported as broken in #13, and reverted in #14. This time I tested in both v24.4 and v25.0.50. Now `ido-at-point-completion-in-region` is also adjusted to behave differently when `completion-in-region-function` is defined.
